### PR TITLE
nix: add nix shell support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  nativeBuildInputs = [
+    ncurses5
+  ];
+  buildInputs = [
+    gcc
+    automake
+    autoconf
+    libtool
+  ];
+}


### PR DESCRIPTION
Add support for the ephemeral nix shell.

How to test?

install [nix](https://nixos.org/download.html#nix-install-linux), enter the project directory and run:

nix-shell

then proceed to the bootstrap and build.

closes #5 