### PR TITLE
fix(makefile): correct the install target

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,15 +21,4 @@ stdenv.mkDerivation rec {
     autoreconf --install
   '';
 
-  installPhase = ''
-    mkdir -p $out/bin
-    chmod -R u+x $out
-
-    cp src/snaskii $out/bin
-    cp src/snaskii.bin $out/bin
-    cp -r scenes $out
-    chmod -R u+x $out/bin
-
-  '';
-
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,17 +50,17 @@ snaskii : snaskii.sh
 # This install snaskii.bin and rename it snaskii.
 
 install-exec-hook: 
-	cd $(DESTDIR)/$(bindir) && mv ttsnake.bin ttsnake
+	cd $(DESTDIR)/$(bindir) && mv $(bin_PROGRAMS) $(bin_SCRIPTS)
 
 # This uninstall the binary
 
 uninstall-hook:
-	rm -f $(DESTDIR)/$(bindir)/snaskii
+	rm -f $(DESTDIR)/$(bindir)/$(bin_SCRIPTS)
 
 # This removes the wrapper script.
 
 clean-local:
-	rm -f snaskii
+	rm -f $(bin_SCRIPTS)
 
 
 


### PR DESCRIPTION
The install target was not working properly.

Use the variables for the bin and script names instead of the erroneous "ttsnake" name. For consistence the variables were used on the other targets also.

closes #12